### PR TITLE
fix: Import ajv from ajv/dist/2020

### DIFF
--- a/.github/workflows/jsonschema.yml
+++ b/.github/workflows/jsonschema.yml
@@ -1,0 +1,23 @@
+name: Check JSON Schemas
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  jsonschema-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@main
+    - uses: sourcemeta/jsonschema@v6.0.3
+    - run: jsonschema metaschema --verbose packages/core/src/ruleset/meta/*.json
+    - run: jsonschema lint --verbose packages/core/src/ruleset/meta/*.json
+
+    # As a smoke test to ensure the schemas at least reference each other well 
+    - run: >
+        jsonschema bundle --verbose 
+        packages/core/src/ruleset/meta/ruleset.schema.json 
+        --resolve packages/core/src/ruleset/meta 
+        --ignore packages/core/src/ruleset/meta/js-extensions.json

--- a/packages/core/src/ruleset/meta/js-extensions.json
+++ b/packages/core/src/ruleset/meta/js-extensions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "@stoplight/spectral-core/meta/extensions",
   "$defs": {
     "Extends": {
@@ -20,13 +20,12 @@
               {
                 "type": "array",
                 "minItems": 2,
-                "additionalItems": false,
-                "items": [
+                "items": false,
+                "prefixItems": [
                   {
                     "$ref": "ruleset"
                   },
                   {
-                    "type": "string",
                     "enum": ["off", "recommended", "all"],
                     "errorMessage": "allowed types are \"off\", \"recommended\" and \"all\""
                   }

--- a/packages/core/src/ruleset/meta/json-extensions.json
+++ b/packages/core/src/ruleset/meta/json-extensions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "@stoplight/spectral-core/meta/extensions",
   "$defs": {
     "Extends": {
@@ -18,8 +18,8 @@
               {
                 "type": "array",
                 "minItems": 2,
-                "additionalItems": false,
-                "items": [
+                "items": false,
+                "prefixItems": [
                   {
                     "type": "string"
                   },

--- a/packages/core/src/ruleset/meta/rule.schema.json
+++ b/packages/core/src/ruleset/meta/rule.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "@stoplight/spectral-core/meta/rule.schema",
   "$defs": {
     "Then": {
@@ -75,7 +75,6 @@
       },
       "type": {
         "enum": ["style", "validation"],
-        "type": "string",
         "errorMessage": "allowed types are \"style\" and \"validation\""
       },
       "extensions": {

--- a/packages/core/src/ruleset/meta/ruleset.schema.json
+++ b/packages/core/src/ruleset/meta/ruleset.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "@stoplight/spectral-core/meta/ruleset.schema",
   "type": "object",
   "additionalProperties": false,

--- a/packages/core/src/ruleset/meta/shared.json
+++ b/packages/core/src/ruleset/meta/shared.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "@stoplight/spectral-core/meta/shared",
   "$defs": {
     "Formats": {

--- a/packages/core/src/ruleset/validation/ajv.ts
+++ b/packages/core/src/ruleset/validation/ajv.ts
@@ -1,4 +1,4 @@
-import Ajv, { _, ValidateFunction } from 'ajv';
+import Ajv, { _, ValidateFunction } from 'ajv/dist/2020';
 import names from 'ajv/dist/compile/names';
 import addFormats from 'ajv-formats';
 import addErrors from 'ajv-errors';


### PR DESCRIPTION
We are using JSONSchema draft 2020-12, which needs ajv/dist/2020. Ref: https://github.com/stoplightio/spectral/pull/2788#issuecomment-2682444647
